### PR TITLE
Move /resume summarization to backend API

### DIFF
--- a/backend-cometi/README.md
+++ b/backend-cometi/README.md
@@ -21,7 +21,7 @@ API serverless pour relayer les requêtes vers OpenAI. Conçu pour être déploy
    npm run dev
    ```
 
-   L’API sera accessible sur `http://localhost:3000/api/chat`.
+   L’API sera accessible sur `http://localhost:3000/api/chat` et `http://localhost:3000/api/resume`.
    > Ce serveur de développement est un petit serveur Node.js (pas besoin du CLI Vercel).
 
 4. Pour simuler exactement l’environnement Vercel (optionnel) :
@@ -34,11 +34,12 @@ API serverless pour relayer les requêtes vers OpenAI. Conçu pour être déploy
 
 1. Connecte le dossier `backend-cometi` à un projet Vercel.
 2. Définis les variables d’environnement dans *Settings → Environment Variables* (`OPENAI_API_KEY`, `OPENAI_MODEL`, `ORIGIN`).
-3. Déploie. L’endpoint public sera `https://<ton-projet>.vercel.app/api/chat`.
+3. Déploie. Les endpoints publics seront `https://<ton-projet>.vercel.app/api/chat` et `https://<ton-projet>.vercel.app/api/resume`.
 
-## Contrat d’API
+## Contrats d’API
 
-- **Méthode** : `POST /api/chat`
+### `POST /api/chat`
+
 - **Corps** :
 
   ```json
@@ -59,3 +60,36 @@ API serverless pour relayer les requêtes vers OpenAI. Conçu pour être déploy
 - **Erreurs** :
   - Statut 400 si la requête est mal formée.
   - Statut 500 si la clé est absente ou si OpenAI renvoie une erreur.
+
+### `POST /api/resume`
+
+- **Corps** :
+
+  ```json
+  {
+    "url": "https://exemple.com/article",
+    "title": "Titre (optionnel)",
+    "domSnapshot": {
+      "html": "<html>…</html>",
+      "title": "Titre DOM (optionnel)"
+    }
+  }
+  ```
+
+  `domSnapshot` est optionnel et permet d’envoyer une capture HTML quand la page est dynamique.
+
+- **Réponse** :
+
+  ```json
+  {
+    "url": "https://exemple.com/article",
+    "title": "Titre détecté",
+    "tldr": ["Puces", "de", "résumé"],
+    "summary": "Résumé long",
+    "usedSources": ["https://exemple.com/article", "https://source-supplémentaire"]
+  }
+  ```
+
+- **Erreurs** :
+  - Statut 400 si l’URL est absente ou non HTTP(S).
+  - Statut 500 si la récupération, l’extraction ou l’appel OpenAI échouent.

--- a/backend-cometi/api/resume.ts
+++ b/backend-cometi/api/resume.ts
@@ -1,0 +1,40 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { processResumeRequest, type ResumeRequestPayload } from '../src/resume';
+
+const ALLOWED_ORIGIN = process.env.ORIGIN ?? '*';
+
+function applyCorsHeaders(res: VercelResponse) {
+  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  applyCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Méthode non autorisée.' });
+    return;
+  }
+
+  try {
+    const payload = (typeof req.body === 'string' ? JSON.parse(req.body) : req.body) as
+      | ResumeRequestPayload
+      | undefined;
+
+    const summary = await processResumeRequest(payload, {
+      apiKey: process.env.OPENAI_API_KEY,
+      model: process.env.OPENAI_MODEL,
+    });
+
+    res.status(200).json(summary);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erreur serveur inattendue.';
+    res.status(500).json({ error: message });
+  }
+}

--- a/backend-cometi/package-lock.json
+++ b/backend-cometi/package-lock.json
@@ -8,9 +8,13 @@
       "name": "backend-cometi",
       "version": "0.1.0",
       "dependencies": {
-        "@vercel/node": "^3.2.12"
+        "@vercel/node": "^3.2.12",
+        "jsdom": "^22.1.0",
+        "pdfjs-dist": "^3.11.174",
+        "tinyld": "^1.3.2"
       },
       "devDependencies": {
+        "@types/jsdom": "^21.1.6",
         "@types/node": "^20.12.7",
         "dotenv": "^16.4.5",
         "tsx": "^4.7.0",
@@ -1012,7 +1016,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -1072,6 +1075,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1086,6 +1101,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/blob": {
       "version": "1.0.2",
@@ -3273,6 +3295,13 @@
         "ts-morph": "12.0.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3430,6 +3459,12 @@
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3485,6 +3520,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/chokidar": {
@@ -3553,6 +3617,18 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3615,6 +3691,66 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3630,6 +3766,34 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -3666,6 +3830,28 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -3677,6 +3863,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3744,11 +3944,68 @@
         "wrappy": "1"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.14.47",
@@ -4203,6 +4460,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
@@ -4263,6 +4536,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
@@ -4298,6 +4580,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4346,17 +4665,80 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/http-errors": {
       "version": "1.4.0",
@@ -4378,6 +4760,20 @@
       "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4492,6 +4888,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4530,6 +4932,82 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
+      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/json-schema-to-ts": {
@@ -4598,6 +5076,15 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "license": "ISC"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4649,7 +5136,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4659,13 +5145,25 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -4741,6 +5239,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -4800,6 +5305,12 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4842,6 +5353,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-browserify": {
@@ -4922,6 +5445,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path2d-polyfill": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
+      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "path2d-polyfill": "^2.0.1"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -4969,6 +5515,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4977,6 +5535,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5068,6 +5632,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -5155,6 +5725,12 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.35"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5202,8 +5778,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -5263,6 +5850,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/stat-mode": {
@@ -5369,6 +5989,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -5421,6 +6047,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyld": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/tinyld/-/tinyld-1.3.4.tgz",
+      "integrity": "sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==",
+      "license": "MIT",
+      "bin": {
+        "tinyld": "bin/tinyld.js",
+        "tinyld-heavy": "bin/tinyld-heavy.js",
+        "tinyld-light": "bin/tinyld-light.js"
+      },
+      "engines": {
+        "node": ">= 12.10.0",
+        "npm": ">= 6.12.0",
+        "yarn": ">= 1.20.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5441,6 +6083,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -5653,6 +6319,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -6021,6 +6697,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
@@ -6033,6 +6721,39 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -6182,6 +6903,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xdg-app-paths": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
@@ -6207,6 +6949,21 @@
       "engines": {
         "node": ">= 6.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/backend-cometi/package.json
+++ b/backend-cometi/package.json
@@ -8,9 +8,13 @@
     "vercel:dev": "vercel dev"
   },
   "dependencies": {
-    "@vercel/node": "^3.2.12"
+    "@vercel/node": "^3.2.12",
+    "jsdom": "^22.1.0",
+    "pdfjs-dist": "^3.11.174",
+    "tinyld": "^1.3.2"
   },
   "devDependencies": {
+    "@types/jsdom": "^21.1.6",
     "@types/node": "^20.12.7",
     "typescript": "^5.4.5",
     "dotenv": "^16.4.5",

--- a/backend-cometi/src/resume/extractMainText.ts
+++ b/backend-cometi/src/resume/extractMainText.ts
@@ -1,0 +1,37 @@
+import { extractTextFromHtml } from './extraction/htmlExtractor';
+import { extractTextFromPdf } from './extraction/pdfExtractor';
+import { deduplicateParagraphs, splitIntoParagraphs } from './utils/text';
+
+export type ExtractionInput = {
+  contentType: 'text/html' | 'application/pdf' | 'unknown';
+  raw: string | ArrayBuffer;
+};
+
+export type ExtractionOutput = {
+  paragraphs: string[];
+  title?: string;
+};
+
+export async function extractMainText(input: ExtractionInput): Promise<ExtractionOutput> {
+  if (input.contentType === 'text/html' && typeof input.raw === 'string') {
+    const result = extractTextFromHtml(input.raw);
+    return {
+      title: result.title,
+      paragraphs: result.paragraphs,
+    };
+  }
+
+  if (input.contentType === 'application/pdf' && input.raw instanceof ArrayBuffer) {
+    const result = await extractTextFromPdf(input.raw);
+    return {
+      paragraphs: result.paragraphs,
+    };
+  }
+
+  if (typeof input.raw === 'string') {
+    const paragraphs = deduplicateParagraphs(splitIntoParagraphs(input.raw));
+    return { paragraphs };
+  }
+
+  return { paragraphs: [] };
+}

--- a/backend-cometi/src/resume/extraction/htmlExtractor.ts
+++ b/backend-cometi/src/resume/extraction/htmlExtractor.ts
@@ -1,0 +1,116 @@
+import { JSDOM } from 'jsdom';
+import { deduplicateParagraphs, normalizeWhitespace } from '../utils/text';
+
+function stripUnwantedNodes(doc: Document) {
+  const removalSelectors = [
+    'script',
+    'style',
+    'noscript',
+    'template',
+    'iframe',
+    'svg',
+    'canvas',
+    'form',
+    'nav',
+    'footer',
+    'header',
+    'aside',
+    'figure',
+    'figcaption',
+    'video',
+    'audio',
+    'button',
+  ];
+
+  doc.querySelectorAll(removalSelectors.join(',')).forEach((node) => {
+    node.remove();
+  });
+}
+
+function selectContentRoot(doc: Document): Element | null {
+  const prioritizedSelectors = [
+    'main',
+    'article',
+    '[role="main"]',
+    'section[role="main"]',
+    'div[role="main"]',
+    'div#content',
+    'div.content',
+    'div[id*="content"]',
+    'div[class*="content"]',
+  ];
+
+  for (const selector of prioritizedSelectors) {
+    const candidate = doc.querySelector(selector);
+    if (candidate && candidate.textContent && candidate.textContent.trim().length > 400) {
+      return candidate;
+    }
+  }
+
+  let bestCandidate: Element | null = null;
+  let bestScore = 0;
+
+  doc.querySelectorAll('p, article, section, div').forEach((element) => {
+    const text = element.textContent?.trim();
+    if (!text || text.length < 200) {
+      return;
+    }
+    const score = text.length;
+    if (score > bestScore) {
+      bestScore = score;
+      bestCandidate = element;
+    }
+  });
+
+  return bestCandidate ?? doc.body;
+}
+
+function collectParagraphs(doc: Document, root: Element | null): string[] {
+  if (!root) {
+    return [];
+  }
+
+  const nodeFilter = doc.defaultView?.NodeFilter ?? { SHOW_TEXT: 4 };
+  const walker = doc.createTreeWalker(root, nodeFilter.SHOW_TEXT);
+  const paragraphs: string[] = [];
+  let current = '';
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    const value = node.textContent;
+    if (!value) {
+      continue;
+    }
+
+    const normalized = normalizeWhitespace(value);
+    if (!normalized) {
+      continue;
+    }
+
+    current = current ? `${current} ${normalized}` : normalized;
+
+    const parent = node.parentElement;
+    if (parent && /^(p|br|li|h[1-6])$/i.test(parent.tagName)) {
+      paragraphs.push(current);
+      current = '';
+    }
+  }
+
+  if (current) {
+    paragraphs.push(current);
+  }
+
+  return deduplicateParagraphs(paragraphs.map((paragraph) => paragraph.trim()).filter(Boolean));
+}
+
+export function extractTextFromHtml(html: string): { title: string; paragraphs: string[] } {
+  const dom = new JSDOM(html);
+  const { document } = dom.window;
+
+  stripUnwantedNodes(document);
+  const contentRoot = selectContentRoot(document);
+  const paragraphs = collectParagraphs(document, contentRoot);
+  const title = document.title?.trim() ?? '';
+
+  return { title, paragraphs };
+}

--- a/backend-cometi/src/resume/extraction/pdfExtractor.ts
+++ b/backend-cometi/src/resume/extraction/pdfExtractor.ts
@@ -1,0 +1,70 @@
+// @ts-expect-error - pdfjs-dist typings are not fully aligned with ESM usage in Node.
+import * as pdfjsLib from 'pdfjs-dist/build/pdf.js';
+import { deduplicateParagraphs, normalizeWhitespace } from '../utils/text';
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = undefined;
+
+function groupItemsByLine(items: Array<{ str: string; transform: number[] }>): string[] {
+  const lines: { y: number; text: string }[] = [];
+
+  items.forEach((item) => {
+    if (!item.str || typeof item.str !== 'string') {
+      return;
+    }
+
+    const text = normalizeWhitespace(item.str);
+    if (!text) {
+      return;
+    }
+
+    const [, , , , , y] = item.transform;
+    const existingLine = lines.find((line) => Math.abs(line.y - y) < 5);
+    if (existingLine) {
+      existingLine.text = `${existingLine.text} ${text}`.trim();
+    } else {
+      lines.push({ y, text });
+    }
+  });
+
+  return lines
+    .sort((a, b) => b.y - a.y)
+    .map((line) => line.text)
+    .filter((line) => line.length > 0);
+}
+
+export async function extractTextFromPdf(buffer: ArrayBuffer): Promise<{ paragraphs: string[] }> {
+  const loadingTask = pdfjsLib.getDocument({ data: buffer, useWorkerFetch: false, disableWorker: true });
+  const pdf = await loadingTask.promise;
+  const pages: string[][] = [];
+
+  for (let pageIndex = 1; pageIndex <= pdf.numPages; pageIndex += 1) {
+    const page = await pdf.getPage(pageIndex);
+    const content = await page.getTextContent();
+    const lines = groupItemsByLine(content.items as Array<{ str: string; transform: number[] }>);
+    pages.push(lines);
+  }
+
+  const occurrences = new Map<string, number>();
+  pages.forEach((lines) => {
+    const unique = new Set(lines.map((line) => line.toLowerCase()));
+    unique.forEach((line) => {
+      const count = occurrences.get(line) ?? 0;
+      occurrences.set(line, count + 1);
+    });
+  });
+
+  const threshold = Math.max(2, Math.floor(pages.length * 0.6));
+  const cleanedLines = pages
+    .flat()
+    .filter((line) => (occurrences.get(line.toLowerCase()) ?? 0) < threshold || line.length > 120);
+
+  const paragraphs = deduplicateParagraphs(
+    cleanedLines
+      .join('\n')
+      .split(/\n{2,}/)
+      .map((paragraph) => normalizeWhitespace(paragraph))
+      .filter((paragraph) => paragraph.length > 0)
+  );
+
+  return { paragraphs };
+}

--- a/backend-cometi/src/resume/index.ts
+++ b/backend-cometi/src/resume/index.ts
@@ -1,0 +1,109 @@
+import { fetchPageContent } from './network/fetchPageContent';
+import { microSearch } from './network/microSearch';
+import { extractMainText } from './extractMainText';
+import { detectLanguage } from './utils/language';
+import { normalizeUrl, isHttpProtocol } from './utils/url';
+import type { ResumeRequestPayload, ResumeServiceEnv, ResumeSummary } from './types';
+import { generateSummary } from './summarize';
+
+const NETWORK_TIMEOUT_MS = 12000;
+const MIN_CONTENT_LENGTH = 800;
+
+export async function processResumeRequest(
+  payload: ResumeRequestPayload | undefined,
+  env: ResumeServiceEnv
+): Promise<ResumeSummary> {
+  if (!payload || typeof payload.url !== 'string') {
+    throw new Error('Corps de requête invalide : URL manquante.');
+  }
+
+  if (!isHttpProtocol(payload.url)) {
+    throw new Error("L'URL fournie doit être accessible via HTTP ou HTTPS.");
+  }
+
+  const normalizedUrl = normalizeUrl(payload.url);
+  const fallbackDom = payload.domSnapshot;
+  let derivedTitle = payload.title ?? '';
+
+  const remote = await fetchPageContent(normalizedUrl, NETWORK_TIMEOUT_MS);
+
+  let contentType: 'text/html' | 'application/pdf' | 'unknown' = 'unknown';
+  let raw: string | ArrayBuffer | undefined;
+
+  if (remote.success) {
+    contentType = remote.contentType;
+    raw = remote.body;
+    if (remote.title) {
+      derivedTitle = remote.title;
+    }
+
+    if (
+      contentType === 'text/html' &&
+      typeof remote.body === 'string' &&
+      remote.body.length < MIN_CONTENT_LENGTH &&
+      fallbackDom?.html
+    ) {
+      contentType = 'text/html';
+      raw = fallbackDom.html;
+      derivedTitle = fallbackDom.title ?? derivedTitle;
+    }
+  } else if (fallbackDom?.html) {
+    contentType = 'text/html';
+    raw = fallbackDom.html;
+    derivedTitle = fallbackDom.title ?? derivedTitle;
+  } else {
+    throw new Error(`Impossible de récupérer le contenu distant : ${remote.error}`);
+  }
+
+  if (!raw) {
+    throw new Error("Aucun contenu exploitable pour générer le résumé.");
+  }
+
+  const extraction = await extractMainText({ contentType, raw });
+  let paragraphs = extraction.paragraphs;
+  const title = extraction.title?.trim() || derivedTitle || normalizedUrl;
+
+  if (paragraphs.length === 0 && fallbackDom?.html && fallbackDom.html !== raw) {
+    const fallbackExtraction = await extractMainText({ contentType: 'text/html', raw: fallbackDom.html });
+    if (fallbackExtraction.paragraphs.length > 0) {
+      paragraphs = fallbackExtraction.paragraphs;
+      if (fallbackExtraction.title) {
+        derivedTitle = fallbackExtraction.title;
+      }
+    }
+  }
+
+  if (paragraphs.length === 0) {
+    throw new Error("Impossible d'extraire le contenu principal de la page.");
+  }
+
+  const joined = paragraphs.join('\n');
+  const supplementalSources: string[] = [];
+
+  if (joined.length < MIN_CONTENT_LENGTH) {
+    const querySeed = title || paragraphs.slice(0, 2).join(' ').slice(0, 120);
+    const searchResults = await microSearch(querySeed, 4);
+    if (searchResults.length > 0) {
+      paragraphs = [
+        ...paragraphs,
+        ...searchResults.map(
+          (result) => `Contexte externe : ${result.title}. ${result.snippet} (source : ${result.url})`
+        ),
+      ];
+      supplementalSources.push(...searchResults.map((result) => result.url));
+    }
+  }
+
+  const language = detectLanguage(paragraphs.join('\n'));
+
+  const summary = await generateSummary(paragraphs, language, normalizedUrl, title, env);
+
+  const usedSources = [normalizedUrl, ...supplementalSources];
+
+  return {
+    ...summary,
+    usedSources,
+  };
+}
+
+export type { ResumeRequestPayload, ResumeSummary, ResumeServiceEnv } from './types';

--- a/backend-cometi/src/resume/network/fetchPageContent.ts
+++ b/backend-cometi/src/resume/network/fetchPageContent.ts
@@ -1,0 +1,95 @@
+import { normalizeWhitespace } from '../utils/text';
+
+export type PageFetchResult =
+  | {
+      success: true;
+      contentType: 'text/html' | 'application/pdf' | 'unknown';
+      body: string | ArrayBuffer;
+      title?: string;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+function detectContentType(headerValue: string | null): 'text/html' | 'application/pdf' | 'unknown' {
+  if (!headerValue) {
+    return 'unknown';
+  }
+
+  const [mime] = headerValue.split(';').map((part) => part.trim().toLowerCase());
+  if (mime === 'text/html' || mime === 'application/xhtml+xml') {
+    return 'text/html';
+  }
+  if (mime === 'application/pdf') {
+    return 'application/pdf';
+  }
+  return 'unknown';
+}
+
+function extractTitleFromHtml(html: string): string | undefined {
+  const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  if (!match) {
+    return undefined;
+  }
+  return normalizeWhitespace(match[1] ?? '').slice(0, 180);
+}
+
+const MAX_CONTENT_LENGTH = 15 * 1024 * 1024;
+
+export async function fetchPageContent(url: string, timeoutMs: number): Promise<PageFetchResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return { success: false, error: `Le serveur a répondu ${response.status}.` };
+    }
+
+    const contentLengthHeader = response.headers.get('content-length');
+    if (contentLengthHeader) {
+      const contentLength = Number(contentLengthHeader);
+      if (Number.isFinite(contentLength) && contentLength > MAX_CONTENT_LENGTH) {
+        return { success: false, error: 'Le contenu distant dépasse la limite autorisée de 15 MB.' };
+      }
+    }
+
+    const contentType = detectContentType(response.headers.get('content-type'));
+
+    if (contentType === 'application/pdf') {
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > MAX_CONTENT_LENGTH) {
+        return { success: false, error: 'Le PDF récupéré dépasse la limite autorisée de 15 MB.' };
+      }
+      return { success: true, contentType, body: buffer };
+    }
+
+    const text = await response.text();
+    if (text.length > MAX_CONTENT_LENGTH) {
+      return { success: false, error: 'Le document HTML récupéré dépasse la limite autorisée.' };
+    }
+
+    return {
+      success: true,
+      contentType,
+      body: text,
+      title: extractTitleFromHtml(text),
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === 'AbortError'
+        ? 'La récupération distante a expiré.'
+        : error instanceof Error
+          ? error.message
+          : 'Échec inattendu lors de la récupération distante.';
+    return { success: false, error: message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/backend-cometi/src/resume/network/microSearch.ts
+++ b/backend-cometi/src/resume/network/microSearch.ts
@@ -1,0 +1,84 @@
+export type SearchResult = {
+  title: string;
+  url: string;
+  snippet: string;
+};
+
+function flattenTopics(topics: Array<Record<string, unknown>>, accumulator: SearchResult[]) {
+  topics.forEach((topic) => {
+    if (Array.isArray(topic.Topics)) {
+      flattenTopics(topic.Topics as Array<Record<string, unknown>>, accumulator);
+      return;
+    }
+
+    const text = typeof topic.Text === 'string' ? topic.Text : undefined;
+    const firstUrl = typeof topic.FirstURL === 'string' ? topic.FirstURL : undefined;
+    const title =
+      typeof topic.Result === 'string'
+        ? topic.Result
+        : typeof topic.Text === 'string'
+          ? topic.Text
+          : undefined;
+
+    if (text && firstUrl) {
+      accumulator.push({
+        title: title ?? text,
+        url: firstUrl,
+        snippet: text,
+      });
+    }
+  });
+}
+
+export async function microSearch(query: string, limit = 4): Promise<SearchResult[]> {
+  const endpoint = `https://duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      redirect: 'follow',
+    });
+
+    if (!response.ok) {
+      throw new Error(`DuckDuckGo a renvoyé ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      RelatedTopics?: Array<Record<string, unknown>>;
+      AbstractText?: string;
+      AbstractURL?: string;
+      Heading?: string;
+    };
+
+    const results: SearchResult[] = [];
+    if (data.AbstractText && data.AbstractURL) {
+      results.push({
+        title: data.Heading ?? data.AbstractText,
+        url: data.AbstractURL,
+        snippet: data.AbstractText,
+      });
+    }
+
+    if (Array.isArray(data.RelatedTopics)) {
+      flattenTopics(data.RelatedTopics, results);
+    }
+
+    const deduped: SearchResult[] = [];
+    const seen = new Set<string>();
+    for (const result of results) {
+      const key = result.url;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      deduped.push(result);
+      if (deduped.length >= limit) {
+        break;
+      }
+    }
+
+    return deduped;
+  } catch (_error) {
+    return [];
+  }
+}

--- a/backend-cometi/src/resume/summarize.ts
+++ b/backend-cometi/src/resume/summarize.ts
@@ -1,0 +1,109 @@
+import type { ChatMessage } from '../chat-service';
+import { processChatRequest } from '../chat-service';
+import type { ResumeServiceEnv, ResumeSummary } from './types';
+import { chunkText } from './utils/text';
+
+const MAX_DIRECT_INPUT_LENGTH = 12000;
+
+async function requestCompletion(messages: ChatMessage[], env: ResumeServiceEnv): Promise<string> {
+  const result = await processChatRequest({ messages }, env);
+
+  if (result.status !== 200 || typeof result.body.message !== 'string') {
+    const backendError = typeof result.body.error === 'string' ? ` (${result.body.error})` : '';
+    throw new Error(`La requête de résumé a échoué${backendError}.`);
+  }
+
+  return result.body.message.trim();
+}
+
+type FinalSummaryPayload = {
+  tldr: string[];
+  summary: string;
+};
+
+function sanitizeJsonPayload(raw: string): unknown {
+  const cleaned = raw.replace(/```json|```/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch (_error) {
+    throw new Error("Le modèle a renvoyé un format de résumé invalide.");
+  }
+}
+
+async function summarizeChunk(text: string, language: string, env: ResumeServiceEnv): Promise<string> {
+  const messages: ChatMessage[] = [
+    {
+      role: 'system',
+      content:
+        'Tu es un assistant qui résume du texte pour un pipeline de synthèse. Réponds dans la même langue que le texte source.',
+    },
+    {
+      role: 'user',
+      content: `Langue attendue : ${language}. Fournis un résumé concis (5 phrases maximum) du passage suivant pour préparer un résumé global.\n\n${text}`,
+    },
+  ];
+
+  return requestCompletion(messages, env);
+}
+
+function buildFinalSummaryPrompt(text: string, language: string, url: string): ChatMessage[] {
+  const systemPrompt =
+    'Tu es un assistant de résumé méticuleux. Retourne toujours un objet JSON avec les champs "tldr" (tableau de 3 à 5 puces concises) et "summary" (un paragraphe de 150 à 220 mots). Sois fidèle au texte fourni.';
+  const userPrompt =
+    `Langue attendue : ${language}. Résume le contenu provenant de ${url}. Fournis des faits vérifiables, aucune spéculation.\n\nCONTENU :\n${text}`;
+
+  return [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userPrompt },
+  ];
+}
+
+export async function generateSummary(
+  paragraphs: string[],
+  language: string,
+  url: string,
+  title: string,
+  env: ResumeServiceEnv
+): Promise<Omit<ResumeSummary, 'usedSources'>> {
+  const combined = paragraphs.join('\n\n');
+  let synthesisSource = combined;
+
+  if (combined.length > MAX_DIRECT_INPUT_LENGTH) {
+    const chunks = chunkText(paragraphs, 4000);
+    const miniSummaries: string[] = [];
+    for (const chunk of chunks) {
+      const chunkSummary = await summarizeChunk(chunk, language, env);
+      miniSummaries.push(chunkSummary);
+    }
+    synthesisSource = miniSummaries.join('\n\n');
+  }
+
+  const messages = buildFinalSummaryPrompt(synthesisSource, language, url);
+  const rawSummary = await requestCompletion(messages, env);
+  const parsed = sanitizeJsonPayload(rawSummary) as Partial<FinalSummaryPayload>;
+
+  if (!parsed || !Array.isArray(parsed.tldr) || typeof parsed.summary !== 'string') {
+    throw new Error('Le modèle a fourni une réponse JSON incomplète.');
+  }
+
+  const tldr = parsed.tldr
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => entry.length > 0)
+    .slice(0, 5);
+
+  if (tldr.length < 3) {
+    throw new Error('Le modèle a fourni trop peu de puces pour le TL;DR.');
+  }
+
+  const summary = parsed.summary.trim();
+  if (summary.length === 0) {
+    throw new Error('Le résumé long est vide.');
+  }
+
+  return {
+    url,
+    title,
+    tldr,
+    summary,
+  };
+}

--- a/backend-cometi/src/resume/types.ts
+++ b/backend-cometi/src/resume/types.ts
@@ -1,0 +1,23 @@
+export type DomSnapshot = {
+  html: string;
+  title?: string;
+};
+
+export type ResumeRequestPayload = {
+  url: string;
+  title?: string;
+  domSnapshot?: DomSnapshot;
+};
+
+export type ResumeSummary = {
+  url: string;
+  title: string;
+  tldr: string[];
+  summary: string;
+  usedSources: string[];
+};
+
+export type ResumeServiceEnv = {
+  apiKey?: string;
+  model?: string;
+};

--- a/backend-cometi/src/resume/utils/language.ts
+++ b/backend-cometi/src/resume/utils/language.ts
@@ -1,0 +1,20 @@
+import { detect } from 'tinyld';
+
+const LANGUAGE_FALLBACK = 'fr';
+
+export function detectLanguage(text: string): string {
+  if (!text) {
+    return LANGUAGE_FALLBACK;
+  }
+
+  try {
+    const detected = detect(text);
+    if (detected && typeof detected === 'string' && detected.length <= 5) {
+      return detected;
+    }
+  } catch (_error) {
+    // ignore detection failure
+  }
+
+  return LANGUAGE_FALLBACK;
+}

--- a/backend-cometi/src/resume/utils/text.ts
+++ b/backend-cometi/src/resume/utils/text.ts
@@ -1,0 +1,54 @@
+const SPACE_REGEX = /\s+/g;
+
+export function normalizeWhitespace(text: string): string {
+  return text.replace(SPACE_REGEX, ' ').trim();
+}
+
+export function splitIntoParagraphs(text: string): string[] {
+  return text
+    .split(/\n{2,}/)
+    .map((paragraph) => normalizeWhitespace(paragraph))
+    .filter((paragraph) => paragraph.length > 0);
+}
+
+function simpleHash(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash.toString(16);
+}
+
+export function deduplicateParagraphs(paragraphs: string[]): string[] {
+  const seen = new Set<string>();
+  return paragraphs.filter((paragraph) => {
+    const key = simpleHash(paragraph.toLowerCase());
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function chunkText(paragraphs: string[], targetSize = 3600): string[] {
+  const chunks: string[] = [];
+  let current = '';
+
+  for (const paragraph of paragraphs) {
+    const candidate = current ? `${current}\n\n${paragraph}` : paragraph;
+    if (candidate.length >= targetSize && current) {
+      chunks.push(current);
+      current = paragraph;
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}

--- a/backend-cometi/src/resume/utils/url.ts
+++ b/backend-cometi/src/resume/utils/url.ts
@@ -1,0 +1,16 @@
+export function normalizeUrl(url: string): string {
+  try {
+    return new URL(url).toString();
+  } catch (_error) {
+    return url;
+  }
+}
+
+export function isHttpProtocol(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (_error) {
+    return false;
+  }
+}

--- a/cometi/README.md
+++ b/cometi/README.md
@@ -13,6 +13,9 @@ Front-end de l’extension Chrome qui s’appuie sur le backend Vercel (`backend
 2. Renseigne `VITE_COMETI_API_URL` :
    - `http://localhost:3000/api/chat` pour consommer le backend lancé en local (`npm run dev` dans `backend-cometi`).
    - l’URL `https://<projet>.vercel.app/api/chat` après déploiement.
+3. Ajoute également `VITE_COMETI_RESUME_URL` vers l’endpoint résumé :
+   - `http://localhost:3000/api/resume` en local.
+   - `https://<projet>.vercel.app/api/resume` en production.
 
 ## Développement
 

--- a/cometi/manifest.json
+++ b/cometi/manifest.json
@@ -20,11 +20,12 @@
     "32": "icons/icon32.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["sidePanel"],
+  "permissions": ["sidePanel", "activeTab", "scripting", "storage"],
   "host_permissions": [
     "https://*.vercel.app/*",
     "http://localhost:3000/*",
-    "http://127.0.0.1:3000/*"
+    "http://127.0.0.1:3000/*",
+    "<all_urls>"
   ],
   "side_panel": {
     "default_path": "sidepanel.html"

--- a/cometi/src/background/network/captureDom.ts
+++ b/cometi/src/background/network/captureDom.ts
@@ -1,0 +1,42 @@
+import { logger } from '../utils/logger';
+
+export type DomCaptureResult = {
+  success: true;
+  html: string;
+  title: string;
+};
+
+export type DomCaptureFailure = {
+  success: false;
+  error: string;
+};
+
+export async function captureRenderedDom(tabId: number): Promise<DomCaptureResult | DomCaptureFailure> {
+  try {
+    const [result] = await chrome.scripting.executeScript<{ html: string; title: string } | undefined>({
+      target: { tabId },
+      func: () => {
+        try {
+          const doc = document;
+          const html = doc.documentElement?.outerHTML ?? '';
+          const title = doc.title ?? '';
+          return { html, title };
+        } catch (error) {
+          console.error('captureRenderedDom: script error', error);
+          return undefined;
+        }
+      },
+    });
+
+    if (!result?.result || typeof result.result.html !== 'string') {
+      return { success: false, error: 'Extraction DOM impossible.' };
+    }
+
+    logger.debug('DOM captured from active tab', { tabId });
+    return { success: true, html: result.result.html, title: result.result.title ?? '' };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Erreur inconnue lors de la capture DOM.';
+    logger.warn('captureRenderedDom failed', { tabId, message });
+    return { success: false, error: message };
+  }
+}

--- a/cometi/src/background/network/chatCompletion.ts
+++ b/cometi/src/background/network/chatCompletion.ts
@@ -1,0 +1,39 @@
+import type { ChatCompletionMessage } from '../types';
+
+const API_URL = import.meta.env.VITE_COMETI_API_URL;
+
+export async function createChatCompletion(messages: ChatCompletionMessage[]): Promise<string> {
+  if (!API_URL) {
+    throw new Error('URL API absente. Ajoute VITE_COMETI_API_URL dans ton fichier .env.');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 12000);
+
+  try {
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ messages }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Le serveur a renvoyé ${response.status} : ${errorText}`);
+    }
+
+    const data = (await response.json()) as { message?: unknown; error?: string };
+
+    if (typeof data?.message !== 'string' || data.message.trim().length === 0) {
+      const backendError = data?.error ? ` (${data.error})` : '';
+      throw new Error(`Réponse invalide du serveur${backendError}.`);
+    }
+
+    return data.message.trim();
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/cometi/src/background/network/getActiveTab.ts
+++ b/cometi/src/background/network/getActiveTab.ts
@@ -1,0 +1,17 @@
+import { logger } from '../utils/logger';
+import { isHttpProtocol } from '../utils/url';
+
+export async function getActiveHttpTab(): Promise<chrome.tabs.Tab> {
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+
+  if (!tab || typeof tab.id !== 'number' || !tab.url) {
+    throw new Error("Impossible de déterminer l'onglet actif.");
+  }
+
+  if (!isHttpProtocol(tab.url)) {
+    throw new Error("L'URL de l'onglet actif doit être accessible via HTTP ou HTTPS.");
+  }
+
+  logger.debug('Active tab selected', { url: tab.url, title: tab.title });
+  return tab;
+}

--- a/cometi/src/background/orchestration/resumeCommand.ts
+++ b/cometi/src/background/orchestration/resumeCommand.ts
@@ -1,0 +1,81 @@
+import { captureRenderedDom } from '../network/captureDom';
+import { getActiveHttpTab } from '../network/getActiveTab';
+import { logger } from '../utils/logger';
+import { normalizeUrl } from '../utils/url';
+import type { ResumeCommandResult } from '../types';
+
+type ResumeCommandPayload = {
+  url: string;
+  title?: string;
+  domSnapshot?: {
+    html: string;
+    title?: string;
+  };
+};
+
+const RESUME_API_URL = import.meta.env.VITE_COMETI_RESUME_URL;
+
+function ensureResumeApiUrl(): string {
+  if (!RESUME_API_URL) {
+    throw new Error('URL API /resume absente. Ajoute VITE_COMETI_RESUME_URL dans ton fichier .env.');
+  }
+  return RESUME_API_URL;
+}
+
+function isValidResumeResult(payload: unknown): payload is ResumeCommandResult {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  const candidate = payload as Partial<ResumeCommandResult>;
+  return (
+    typeof candidate.url === 'string' &&
+    typeof candidate.title === 'string' &&
+    Array.isArray(candidate.tldr) &&
+    typeof candidate.summary === 'string' &&
+    Array.isArray(candidate.usedSources)
+  );
+}
+
+export async function handleResumeCommand(): Promise<ResumeCommandResult> {
+  const tab = await getActiveHttpTab();
+  const normalizedUrl = normalizeUrl(tab.url ?? '');
+
+  const payload: ResumeCommandPayload = {
+    url: normalizedUrl,
+    title: tab.title ?? undefined,
+  };
+
+  if (typeof tab.id === 'number') {
+    const dom = await captureRenderedDom(tab.id);
+    if (dom.success && dom.html.trim().length > 0) {
+      payload.domSnapshot = { html: dom.html, title: dom.title || undefined };
+    } else if (!dom.success) {
+      logger.debug('Capture DOM indisponible', { reason: dom.error });
+    }
+  }
+
+  const response = await fetch(ensureResumeApiUrl(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json().catch(() => undefined);
+
+  if (!response.ok) {
+    const errorMessage =
+      data && typeof data.error === 'string'
+        ? data.error
+        : `Le serveur résumé a renvoyé ${response.status}.`;
+    throw new Error(errorMessage);
+  }
+
+  if (!isValidResumeResult(data)) {
+    throw new Error('Réponse invalide du service de résumé.');
+  }
+
+  return data;
+}

--- a/cometi/src/background/types.ts
+++ b/cometi/src/background/types.ts
@@ -1,0 +1,43 @@
+export type ChatCompletionMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+export type ChatCompletionRequest = {
+  type: 'chat:complete';
+  payload: {
+    messages: ChatCompletionMessage[];
+  };
+};
+
+export type ChatCompletionResponse =
+  | {
+      message: string;
+    }
+  | {
+      error: string;
+    };
+
+export type ResumeCommandRequest = {
+  type: 'commands:resume';
+};
+
+export type ResumeCommandSuccess = {
+  ok: true;
+  result: ResumeCommandResult;
+};
+
+export type ResumeCommandFailure = {
+  ok: false;
+  error: string;
+};
+
+export type ResumeCommandResponse = ResumeCommandSuccess | ResumeCommandFailure;
+
+export type ResumeCommandResult = {
+  url: string;
+  title: string;
+  tldr: string[];
+  summary: string;
+  usedSources: string[];
+};

--- a/cometi/src/background/utils/logger.ts
+++ b/cometi/src/background/utils/logger.ts
@@ -1,0 +1,20 @@
+const isDev = import.meta.env.MODE === 'development';
+
+export const logger = {
+  debug(message: string, context?: unknown) {
+    if (isDev) {
+      console.debug(`[Cometi::background] ${message}`, context ?? '');
+    }
+  },
+  info(message: string, context?: unknown) {
+    if (isDev) {
+      console.info(`[Cometi::background] ${message}`, context ?? '');
+    }
+  },
+  warn(message: string, context?: unknown) {
+    console.warn(`[Cometi::background] ${message}`, context ?? '');
+  },
+  error(message: string, context?: unknown) {
+    console.error(`[Cometi::background] ${message}`, context ?? '');
+  },
+};

--- a/cometi/src/background/utils/url.ts
+++ b/cometi/src/background/utils/url.ts
@@ -1,0 +1,16 @@
+export function isHttpProtocol(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (_error) {
+    return false;
+  }
+}
+
+export function normalizeUrl(url: string): string {
+  try {
+    return new URL(url).toString();
+  } catch (_error) {
+    return url;
+  }
+}

--- a/cometi/src/sidepanel/services/resumeCommand.ts
+++ b/cometi/src/sidepanel/services/resumeCommand.ts
@@ -1,0 +1,51 @@
+import type { ResumeSummary } from '../types/resume';
+
+class ResumeCommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResumeCommandError';
+  }
+}
+
+type ResumeCommandRequest = {
+  type: 'commands:resume';
+};
+
+type ResumeCommandResponse =
+  | {
+      ok: true;
+      result: ResumeSummary;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export async function requestResumeSummary(): Promise<ResumeSummary> {
+  if (typeof chrome === 'undefined' || typeof chrome.runtime?.sendMessage !== 'function') {
+    throw new ResumeCommandError('Commande disponible uniquement dans Chrome.');
+  }
+
+  return new Promise<ResumeSummary>((resolve, reject) => {
+    const request: ResumeCommandRequest = { type: 'commands:resume' };
+
+    chrome.runtime.sendMessage(request, (response?: ResumeCommandResponse) => {
+      if (chrome.runtime.lastError) {
+        reject(new ResumeCommandError(chrome.runtime.lastError.message));
+        return;
+      }
+
+      if (!response) {
+        reject(new ResumeCommandError('Réponse vide du service d’arrière-plan.'));
+        return;
+      }
+
+      if (!response.ok) {
+        reject(new ResumeCommandError(response.error ?? 'La commande /resume a échoué.'));
+        return;
+      }
+
+      resolve(response.result);
+    });
+  });
+}

--- a/cometi/src/sidepanel/types/chat.ts
+++ b/cometi/src/sidepanel/types/chat.ts
@@ -5,9 +5,22 @@ export type ChromeChatMessage = {
   content: string;
 };
 
+export type MessageAction =
+  | {
+      type: 'copy';
+      label: string;
+      value: string;
+    }
+  | {
+      type: 'open';
+      label: string;
+      url: string;
+    };
+
 export type ConversationMessage = {
   id: number;
   role: Role;
   text: string;
   isError?: boolean;
+  actions?: MessageAction[];
 };

--- a/cometi/src/sidepanel/types/resume.ts
+++ b/cometi/src/sidepanel/types/resume.ts
@@ -1,0 +1,7 @@
+export type ResumeSummary = {
+  url: string;
+  title: string;
+  tldr: string[];
+  summary: string;
+  usedSources: string[];
+};


### PR DESCRIPTION
## Summary
- move the /resume extraction and summarisation pipeline from the extension background script into the backend service with a dedicated /api/resume endpoint
- add server-side fetching, HTML/PDF extraction, micro-search, and summarisation utilities that reuse DOM snapshots when available
- update the extension background command to call the backend endpoint and document the new VITE_COMETI_RESUME_URL configuration

## Testing
- npm run build
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e4f439ddd0832395bac0c98ee2e1e2