### PR TITLE
Expose GPT suggestions in the composer

### DIFF
--- a/backend-cometi/README.md
+++ b/backend-cometi/README.md
@@ -7,6 +7,7 @@ API serverless pour relayer les requêtes vers OpenAI. Conçu pour être déploy
 1. Copie `.env.example` en `.env` (ou définis les variables dans le dashboard Vercel) :
    - `OPENAI_API_KEY` : ta clé OpenAI.
    - `OPENAI_MODEL` : identifiant de modèle (ex. `gpt-4o-mini`).
+   - `OPENAI_SUGGESTIONS_MODEL` : (optionnel) modèle dédié aux suggestions (défaut `gpt-4.1-nano`).
    - `ORIGIN` : domaine autorisé pour le CORS (ex. `chrome-extension://...`). Laisse `*` pour du debug.
    - (Optionnel) Embeddings pour le résumé: 
      - `DB_EMBEDDING` : URL PostgreSQL (Neon) ex: `postgresql://user:pass@host/db?sslmode=require`
@@ -26,7 +27,7 @@ API serverless pour relayer les requêtes vers OpenAI. Conçu pour être déploy
    npm run dev
    ```
 
-   L’API sera accessible sur `http://localhost:3000/api/chat` et `http://localhost:3000/api/resume`.
+   L’API sera accessible sur `http://localhost:3000/api/chat`, `http://localhost:3000/api/suggestions` et `http://localhost:3000/api/resume`.
    > Ce serveur de développement est un petit serveur Node.js (pas besoin du CLI Vercel).
 
 ### Activer la DB d’embeddings (PostgreSQL)
@@ -116,3 +117,31 @@ API serverless pour relayer les requêtes vers OpenAI. Conçu pour être déploy
 - **Erreurs** :
   - Statut 400 si l’URL est absente ou non HTTP(S).
   - Statut 500 si la récupération, l’extraction ou l’appel OpenAI échouent.
+
+### `POST /api/suggestions`
+
+- **Corps** :
+
+  ```json
+  {
+    "domain": "twitter.com",
+    "context": "Titre du post ou extrait",
+    "language": "fr"
+  }
+  ```
+
+  `context` et `language` sont optionnels. Si `language` n’est pas fourni, le français est utilisé.
+
+- **Réponse** :
+
+  ```json
+  {
+    "suggestions": [
+      { "id": 1, "label": "Résumer les commentaires" },
+      { "id": 2, "label": "Lister les points clés" }
+    ]
+  }
+  ```
+
+- **Erreurs** :
+  - Statut 500 si la clé API est absente ou si la réponse OpenAI n’est pas exploitable.

--- a/backend-cometi/src/suggestions-service.ts
+++ b/backend-cometi/src/suggestions-service.ts
@@ -1,0 +1,163 @@
+const OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL = 'gpt-4.1-nano';
+
+export type SuggestionPayload = {
+  domain?: string;
+  context?: string;
+  language?: 'fr' | 'en';
+};
+
+export type Suggestion = {
+  id: number;
+  label: string;
+};
+
+export type SuggestionServiceEnv = {
+  apiKey?: string;
+  model?: string;
+};
+
+export type SuggestionServiceResult = {
+  status: number;
+  body: {
+    suggestions?: Suggestion[];
+    error?: string;
+  };
+};
+
+function buildPrompt(payload: SuggestionPayload): { role: 'system' | 'user'; content: string }[] {
+  const language = payload.language ?? 'fr';
+  const intro =
+    language === 'fr'
+      ?
+        "Tu es un générateur de suggestions d'actions pour une extension de navigateur. " +
+        'Tu dois toujours renvoyer un JSON strict conforme au schéma {"suggestions": [{"id": number, "label": string}]}. '
+      :
+        'You generate action suggestions for a browser extension. ' +
+        'Always respond with strict JSON using the schema {"suggestions": [{"id": number, "label": string}]}. ';
+
+  const tone =
+    language === 'fr'
+      ?
+        'Les labels doivent être de courtes commandes utiles (maximum 60 caractères), adaptées au site, et commencer par un verbe. '
+      :
+        'Labels must be short actionable commands (max 60 characters) tailored to the site and start with a verb. ';
+
+  const systemMessage = `${intro}${tone}Numérote les suggestions de 1 à 5.`;
+
+  const siteDescriptionParts = [] as string[];
+  if (payload.domain) {
+    siteDescriptionParts.push(
+      language === 'fr'
+        ? `Domaine: ${payload.domain}`
+        : `Domain: ${payload.domain}`
+    );
+  }
+  if (payload.context) {
+    siteDescriptionParts.push(
+      language === 'fr'
+        ? `Contexte: ${payload.context}`
+        : `Context: ${payload.context}`
+    );
+  }
+
+  const userMessage =
+    siteDescriptionParts.length > 0
+      ? siteDescriptionParts.join('\n')
+      : language === 'fr'
+        ? "Génère des suggestions génériques pour une page web sans contexte."
+        : 'Generate generic suggestions for a web page with no context.';
+
+  return [
+    { role: 'system', content: systemMessage },
+    { role: 'user', content: userMessage },
+  ];
+}
+
+function parseSuggestions(raw: string | undefined): Suggestion[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      Array.isArray((parsed as any).suggestions)
+    ) {
+      const suggestions = (parsed as any).suggestions
+        .filter((item: any) => typeof item === 'object' && item !== null)
+        .map((item: any, index: number) => {
+          const id = Number.isInteger(item.id) ? item.id : index + 1;
+          const label = typeof item.label === 'string' ? item.label.trim() : '';
+          const suggestion: Suggestion = { id, label };
+          return suggestion;
+        })
+        .filter((item: Suggestion) => item.label.length > 0);
+
+      if (suggestions.length > 0) {
+        return suggestions;
+      }
+    }
+  } catch (error) {
+    console.error('[suggestions] JSON parse error', error);
+  }
+  return undefined;
+}
+
+export async function processSuggestionRequest(
+  payload: SuggestionPayload | undefined,
+  env: SuggestionServiceEnv
+): Promise<SuggestionServiceResult> {
+  if (!env.apiKey) {
+    return {
+      status: 500,
+      body: { error: 'OPENAI_API_KEY manquante côté serveur.' },
+    };
+  }
+
+  const messages = buildPrompt(payload ?? {});
+  const model = env.model ?? DEFAULT_MODEL;
+
+  console.log(
+    `[suggestions] model=${model} domain=${payload?.domain ?? '<none>'} contextLen=${payload?.context?.length ?? 0}`
+  );
+
+  const response = await fetch(OPENAI_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${env.apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      response_format: { type: 'json_object' },
+      messages,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    return {
+      status: response.status,
+      body: { error: `OpenAI a renvoyé ${response.status}: ${text}` },
+    };
+  }
+
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+
+  const content = data?.choices?.[0]?.message?.content;
+  const suggestions = parseSuggestions(content);
+
+  if (!suggestions) {
+    return {
+      status: 500,
+      body: { error: "OpenAI n'a pas renvoyé de JSON exploitable." },
+    };
+  }
+
+  return {
+    status: 200,
+    body: { suggestions },
+  };
+}

--- a/cometi/.env.example
+++ b/cometi/.env.example
@@ -6,3 +6,4 @@ VITE_COMETI_API_BASE=http://localhost:3000/api
 # (Optionnel) Surcharges spécifiques si besoin
 # VITE_COMETI_API_URL=http://localhost:3000/api/chat
 # VITE_COMETI_RESUME_URL=http://localhost:3000/api/resume
+# VITE_COMETI_SUGGESTIONS_URL=http://localhost:3000/api/suggestions

--- a/cometi/README.md
+++ b/cometi/README.md
@@ -17,6 +17,7 @@ Front-end de l’extension Chrome qui s’appuie sur le backend Vercel (`backend
 3. (Optionnel) Tu peux surcharger les URLs précises si besoin:
    - `VITE_COMETI_API_URL` pour `POST /api/chat`
    - `VITE_COMETI_RESUME_URL` pour `POST /api/resume`
+   - `VITE_COMETI_SUGGESTIONS_URL` pour `POST /api/suggestions`
 
 ## Développement
 

--- a/cometi/src/sidepanel/App.tsx
+++ b/cometi/src/sidepanel/App.tsx
@@ -2,9 +2,11 @@ import { useConversation } from './hooks/useConversation';
 import { ConversationThread } from './components/ConversationThread';
 import { Composer } from './components/Composer';
 import { ScrollArea } from './components/ui/scroll-area';
+import { useSuggestions } from './hooks/useSuggestions';
 
 export function App(): JSX.Element {
   const { messages, draft, setDraft, isLoading, handleSubmit } = useConversation();
+  const { suggestions, isLoading: areSuggestionsLoading, error: suggestionsError, refresh } = useSuggestions();
 
   return (
     <div className="flex h-screen w-full justify-center px-2 py-2 sm:px-6">
@@ -14,7 +16,16 @@ export function App(): JSX.Element {
             <ConversationThread messages={messages} isLoading={isLoading} />
           </ScrollArea>
         </div>
-        <Composer draft={draft} onDraftChange={setDraft} onSubmit={handleSubmit} isSubmitting={isLoading} />
+        <Composer
+          draft={draft}
+          onDraftChange={setDraft}
+          onSubmit={handleSubmit}
+          isSubmitting={isLoading}
+          suggestions={suggestions}
+          areSuggestionsLoading={areSuggestionsLoading}
+          suggestionsError={suggestionsError}
+          onRefreshSuggestions={refresh}
+        />
       </div>
     </div>
   );

--- a/cometi/src/sidepanel/components/Composer.tsx
+++ b/cometi/src/sidepanel/components/Composer.tsx
@@ -5,15 +5,30 @@ import { Textarea } from './ui/textarea';
 import { PaperAirplaneIcon } from './icons';
 import { SlashCommandMenu, SlashCommand } from './SlashCommandMenu';
 import { SLASH_COMMANDS } from '../commands';
+import { SuggestionsTray } from './SuggestionsTray';
+import type { Suggestion } from '../types/suggestions';
 
 type ComposerProps = {
   draft: string;
   onDraftChange: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   isSubmitting: boolean;
+  suggestions: Suggestion[];
+  areSuggestionsLoading: boolean;
+  suggestionsError?: string;
+  onRefreshSuggestions?: () => void;
 };
 
-export function Composer({ draft, onDraftChange, onSubmit, isSubmitting }: ComposerProps): JSX.Element {
+export function Composer({
+  draft,
+  onDraftChange,
+  onSubmit,
+  isSubmitting,
+  suggestions,
+  areSuggestionsLoading,
+  suggestionsError,
+  onRefreshSuggestions,
+}: ComposerProps): JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isSlashOpen, setIsSlashOpen] = useState(false);
   const [slashActiveIndex, setSlashActiveIndex] = useState(0);
@@ -76,85 +91,106 @@ export function Composer({ draft, onDraftChange, onSubmit, isSubmitting }: Compo
   return (
     <form
       onSubmit={onSubmit}
-      className="flex items-end gap-3 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm"
+      className="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm"
     >
-      <Textarea
-        ref={textareaRef}
-        value={draft}
-        onChange={(event) => {
-          const next = event.target.value;
-          onDraftChange(next);
-          adjustTextareaSize(event.currentTarget);
-          // toggle slash menu based on new content
-          setIsSlashOpen(next.startsWith('/'));
-        }}
-        rows={1}
-        placeholder="Écrire un message…"
-        variant="plain"
-        className="max-h-64 flex-1 leading-relaxed"
-        disabled={isSubmitting}
-        onKeyDown={(event) => {
-          if (isSlashOpen) {
-            // navigation for slash menu
-            if (event.key === 'ArrowDown') {
-              event.preventDefault();
-              setSlashActiveIndex((idx) => (slashItems.length ? (idx + 1) % slashItems.length : 0));
-              return;
-            }
-            if (event.key === 'ArrowUp') {
-              event.preventDefault();
-              setSlashActiveIndex((idx) => (slashItems.length ? (idx - 1 + slashItems.length) % slashItems.length : 0));
-              return;
-            }
-            if (event.key === 'Tab') {
-              event.preventDefault();
-              if (slashItems.length) applySlashSelection(slashItems[slashActiveIndex], false);
-              return;
-            }
-            if (event.key === 'Enter' && !event.shiftKey) {
-              if (slashItems.length) {
-                event.preventDefault();
-                applySlashSelection(slashItems[slashActiveIndex], true);
-                return;
+      <div className="flex flex-col gap-3">
+        <SuggestionsTray
+          suggestions={suggestions}
+          isLoading={areSuggestionsLoading}
+          error={suggestionsError}
+          onRetry={onRefreshSuggestions}
+          onSelect={(suggestion) => {
+            onDraftChange(suggestion.label);
+            requestAnimationFrame(() => {
+              if (textareaRef.current) {
+                textareaRef.current.focus();
+                adjustTextareaSize(textareaRef.current);
               }
-              // no items -> close and let normal enter handling run below
-              setIsSlashOpen(false);
-              // do not return; fall through to normal submit handler
-            }
-            if (event.key === 'Escape') {
-              event.preventDefault();
-              setIsSlashOpen(false);
-              return;
-            }
-          }
+            });
+          }}
+        />
+        <div className="flex items-end gap-3">
+          <div className="flex-1">
+            <Textarea
+              ref={textareaRef}
+              value={draft}
+              onChange={(event) => {
+                const next = event.target.value;
+                onDraftChange(next);
+                adjustTextareaSize(event.currentTarget);
+                // toggle slash menu based on new content
+                setIsSlashOpen(next.startsWith('/'));
+              }}
+              rows={1}
+              placeholder="Écrire un message…"
+              variant="plain"
+              className="max-h-64 w-full leading-relaxed"
+              disabled={isSubmitting}
+              onKeyDown={(event) => {
+                if (isSlashOpen) {
+                  // navigation for slash menu
+                  if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    setSlashActiveIndex((idx) => (slashItems.length ? (idx + 1) % slashItems.length : 0));
+                    return;
+                  }
+                  if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    setSlashActiveIndex((idx) => (slashItems.length ? (idx - 1 + slashItems.length) % slashItems.length : 0));
+                    return;
+                  }
+                  if (event.key === 'Tab') {
+                    event.preventDefault();
+                    if (slashItems.length) applySlashSelection(slashItems[slashActiveIndex], false);
+                    return;
+                  }
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    if (slashItems.length) {
+                      event.preventDefault();
+                      applySlashSelection(slashItems[slashActiveIndex], true);
+                      return;
+                    }
+                    // no items -> close and let normal enter handling run below
+                    setIsSlashOpen(false);
+                    // do not return; fall through to normal submit handler
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    setIsSlashOpen(false);
+                    return;
+                  }
+                }
 
-          if (event.key === 'Enter' && !event.shiftKey) {
-            event.preventDefault();
-            if (!isSubmitting && event.currentTarget.value.trim().length > 0) {
-              event.currentTarget.form?.requestSubmit();
-            }
-          }
-        }}
-        // Set an initial height to prevent first-render jump
-        style={{ overflowY: 'hidden', height: 44 }}
-      />
-      <SlashCommandMenu
-        open={isSlashOpen}
-        items={slashItems}
-        activeIndex={slashActiveIndex}
-        onActiveIndexChange={setSlashActiveIndex}
-        anchor={textareaRef.current}
-        onClose={() => setIsSlashOpen(false)}
-        onSelect={(cmd) => applySlashSelection(cmd, true)}
-      />
-      <Button
-        type="submit"
-        aria-label="Envoyer le message"
-        disabled={isSubmitting || draft.trim().length === 0}
-        className="h-10 w-10 rounded-full bg-slate-900 text-white hover:bg-slate-800"
-      >
-        <PaperAirplaneIcon className="h-4 w-4" />
-      </Button>
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault();
+                  if (!isSubmitting && event.currentTarget.value.trim().length > 0) {
+                    event.currentTarget.form?.requestSubmit();
+                  }
+                }
+              }}
+              // Set an initial height to prevent first-render jump
+              style={{ overflowY: 'hidden', height: 44 }}
+            />
+          </div>
+          <SlashCommandMenu
+            open={isSlashOpen}
+            items={slashItems}
+            activeIndex={slashActiveIndex}
+            onActiveIndexChange={setSlashActiveIndex}
+            anchor={textareaRef.current}
+            onClose={() => setIsSlashOpen(false)}
+            onSelect={(cmd) => applySlashSelection(cmd, true)}
+          />
+          <Button
+            type="submit"
+            aria-label="Envoyer le message"
+            disabled={isSubmitting || draft.trim().length === 0}
+            className="h-10 w-10 rounded-full bg-slate-900 text-white hover:bg-slate-800"
+          >
+            <PaperAirplaneIcon className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
     </form>
   );
 }

--- a/cometi/src/sidepanel/components/SuggestionsTray.tsx
+++ b/cometi/src/sidepanel/components/SuggestionsTray.tsx
@@ -1,0 +1,56 @@
+import type { Suggestion } from '../types/suggestions';
+import { Button } from './ui/button';
+
+const PLACEHOLDER_ITEMS = Array.from({ length: 3 });
+
+type SuggestionsTrayProps = {
+  suggestions: Suggestion[];
+  isLoading: boolean;
+  error?: string;
+  onSelect: (suggestion: Suggestion) => void;
+  onRetry?: () => void;
+};
+
+export function SuggestionsTray({ suggestions, isLoading, error, onSelect, onRetry }: SuggestionsTrayProps): JSX.Element | null {
+  if (!isLoading && !error && suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {isLoading
+        ? PLACEHOLDER_ITEMS.map((_, index) => (
+            <span
+              key={`placeholder-${index}`}
+              className="h-8 w-32 animate-pulse rounded-full bg-slate-100"
+              aria-hidden
+            />
+          ))
+        : null}
+
+      {!isLoading && error ? (
+        <div className="flex flex-wrap items-center gap-2 text-sm text-slate-500">
+          <span>{error}</span>
+          {onRetry ? (
+            <Button type="button" variant="ghost" onClick={onRetry} className="h-7 rounded-full px-3 text-xs">
+              Réessayer
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {!isLoading && !error
+        ? suggestions.map((suggestion) => (
+            <button
+              key={suggestion.id}
+              type="button"
+              onClick={() => onSelect(suggestion)}
+              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-100"
+            >
+              {suggestion.label}
+            </button>
+          ))
+        : null}
+    </div>
+  );
+}

--- a/cometi/src/sidepanel/hooks/useSuggestions.ts
+++ b/cometi/src/sidepanel/hooks/useSuggestions.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { requestSuggestions } from '../services/suggestionsClient';
+import { requestResumeContext } from '../services/pageAnswerStream';
+import type { Suggestion } from '../types/suggestions';
+
+type SuggestionsState = {
+  suggestions: Suggestion[];
+  isLoading: boolean;
+  error?: string;
+};
+
+const INITIAL_STATE: SuggestionsState = {
+  suggestions: [],
+  isLoading: true,
+};
+
+function getDomainFromUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function getFallbackDomain(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return window.location.hostname || undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+export function useSuggestions() {
+  const [state, setState] = useState<SuggestionsState>(INITIAL_STATE);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const refresh = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setState((prev) => ({ ...prev, isLoading: true, error: undefined }));
+
+      try {
+        let domain: string | undefined;
+        let context: string | undefined;
+
+        try {
+          const resumeContext = await requestResumeContext();
+          domain = getDomainFromUrl(resumeContext.url);
+          context = resumeContext.title ?? resumeContext.domSnapshot?.title ?? undefined;
+        } catch (error) {
+          console.warn('[Cometi] Impossible de récupérer le contexte page pour les suggestions:', error);
+          domain = getFallbackDomain();
+        }
+
+        const suggestions = await requestSuggestions({ domain, context, language: 'fr' });
+
+        if (!cancelled) {
+          setState({ suggestions, isLoading: false, error: undefined });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          const message =
+            error instanceof Error ? error.message : "Impossible de récupérer les suggestions disponibles.";
+          setState({ suggestions: [], isLoading: false, error: message });
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  return useMemo(
+    () => ({
+      suggestions: state.suggestions,
+      isLoading: state.isLoading,
+      error: state.error,
+      refresh,
+    }),
+    [state.suggestions, state.isLoading, state.error, refresh]
+  );
+}

--- a/cometi/src/sidepanel/services/suggestionsClient.ts
+++ b/cometi/src/sidepanel/services/suggestionsClient.ts
@@ -1,0 +1,66 @@
+import type { Suggestion } from '../types/suggestions';
+
+type SuggestionResponse = {
+  suggestions?: Array<{ id?: unknown; label?: unknown }>;
+  error?: unknown;
+};
+
+const API_BASE = (import.meta.env.VITE_COMETI_API_BASE ?? '').replace(/\/+$/, '');
+const SUGGESTIONS_URL =
+  import.meta.env.VITE_COMETI_SUGGESTIONS_URL || (API_BASE ? `${API_BASE}/suggestions` : undefined);
+
+function ensureSuggestionsUrl(): string {
+  if (!SUGGESTIONS_URL) {
+    throw new Error(
+      "URL API /suggestions absente. Ajoute VITE_COMETI_API_BASE (ex: http://localhost:3000/api) ou VITE_COMETI_SUGGESTIONS_URL dans ton fichier .env."
+    );
+  }
+  return SUGGESTIONS_URL;
+}
+
+function normalizeSuggestions(payload: SuggestionResponse): Suggestion[] {
+  if (!payload || !Array.isArray(payload.suggestions)) {
+    throw new Error('Réponse invalide du service de suggestions.');
+  }
+
+  const mapped = payload.suggestions
+    .map((raw, index): Suggestion | null => {
+      if (!raw || typeof raw !== 'object') return null;
+      const label = typeof raw.label === 'string' ? raw.label.trim() : '';
+      if (!label) return null;
+      const idValue = raw.id;
+      const id = typeof idValue === 'number' && Number.isInteger(idValue) ? idValue : index + 1;
+      return { id, label };
+    })
+    .filter((item): item is Suggestion => item !== null);
+
+  return mapped;
+}
+
+export async function requestSuggestions(payload: {
+  domain?: string;
+  context?: string;
+  language?: 'fr' | 'en';
+}): Promise<Suggestion[]> {
+  const response = await fetch(ensureSuggestionsUrl(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Le service de suggestions a renvoyé ${response.status}. ${text}`.trim());
+  }
+
+  const data = (await response.json().catch(() => undefined)) as SuggestionResponse | undefined;
+  if (!data) {
+    throw new Error('Réponse vide du service de suggestions.');
+  }
+
+  if (typeof data.error === 'string' && data.error.trim().length > 0) {
+    throw new Error(data.error.trim());
+  }
+
+  return normalizeSuggestions(data);
+}

--- a/cometi/src/sidepanel/types/suggestions.ts
+++ b/cometi/src/sidepanel/types/suggestions.ts
@@ -1,0 +1,4 @@
+export type Suggestion = {
+  id: number;
+  label: string;
+};


### PR DESCRIPTION
## Summary
- fetch GPT-driven suggestions for the active page and surface them above the sidepanel composer input
- add a reusable suggestions tray, client, and hook to request the backend /suggestions endpoint with page context
- document the optional VITE_COMETI_SUGGESTIONS_URL override for local and production setups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55ba6dbf883238a09bfac43828701