### PR TITLE
Add mode-aware route agent itinerary selection

### DIFF
--- a/cometi/src/sidepanel/services/routeAgent.ts
+++ b/cometi/src/sidepanel/services/routeAgent.ts
@@ -1,4 +1,10 @@
-export type RouteVariant = { durationMin: number; distanceKm?: number; text?: string };
+export type RouteVariant = {
+  durationMin: number;
+  distanceKm?: number;
+  text?: string;
+  mode?: string;
+  modeLabel?: string;
+};
 export type RouteComputeResult = { routes: RouteVariant[]; best: RouteVariant | null };
 
 type BgResponse = { ok: boolean; result?: RouteComputeResult; error?: string };
@@ -7,6 +13,7 @@ export async function computeFastestRouteViaBackground(params: {
   origin: string;
   destination: string;
   language?: string;
+  mode?: string;
 }): Promise<RouteComputeResult> {
   if (typeof chrome === 'undefined' || typeof chrome.runtime?.sendMessage !== 'function') {
     throw new Error('Commande disponible uniquement dans Chrome.');


### PR DESCRIPTION
## Summary
- allow the background route automation to honor requested travel modes and switch the Google Maps UI accordingly
- collect at least three and up to five itinerary variants across modes while enriching route results with mode metadata
- infer transport mode hints from user requests in the sidepanel and surface richer facts to the LLM response

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6385f76c08323bc921b0519747624